### PR TITLE
Be more conservative about dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "Eight Media",
   "license": "MIT",
   "dependencies": {
-    "consolidate": "*",
+    "consolidate": "~0.10.0",
     "css-parse": "*",
     "highlight.js": "^8.1.0",
     "jade": "~1.1.4",


### PR DESCRIPTION
The module "consolidate" saw a minor update a couple of days ago. That update breaks styleguidejs. Hence the version fix.
